### PR TITLE
no maven

### DIFF
--- a/docs/xbuilder/installation.md
+++ b/docs/xbuilder/installation.md
@@ -54,8 +54,8 @@ Se recomienda que todo proyecto esté hecho usando Maven o Gradle ya que facilit
     <dependencies>
         <dependency>
             <groupId>io.github.project-openubl</groupId>
-            <artifactId>xsender</artifactId>
-            <version>3.0.1.Final</version>
+            <artifactId>xbuilder</artifactId>
+            <version>UltimaVersion</version>
         </dependency>
     </dependencies>
 </project>

--- a/docs/xbuilder/installation.md
+++ b/docs/xbuilder/installation.md
@@ -72,4 +72,4 @@ mvn dependency:copy-dependencies
 
 ### Ejemplo
 
-`Carlos Alberto` Nos muestra un ejemplo de cómo usar las dependencias sin Maven o Gradle en [project-xbuilder-xsender-NO-MAVEN-GRADLE](https://github.com/xxsolracxx/project-xbuilder-xsender-NO-MAVEN-GRADLE)
+Este ejemplo muestra cómo usar las dependencias sin Maven o Gradle en [project-xbuilder-xsender-NO-MAVEN-GRADLE](https://github.com/xxsolracxx/project-xbuilder-xsender-NO-MAVEN-GRADLE)

--- a/docs/xbuilder/installation.md
+++ b/docs/xbuilder/installation.md
@@ -29,3 +29,47 @@ compile group: 'io.github.project-openubl', name: 'xbuilder', version: 'EscribaL
 ```
 
 > Reemplaze `UltimaVersion` por una versión válida.
+
+## No uso Maven ni Gradle ¿Cómo instalar XBuilder?
+
+Se recomienda que todo proyecto esté hecho usando Maven o Gradle ya que facilita y automatiza el proceso de descarga de dependencias. Te recomendamos:
+
+- Evaluar cambiar tu código y empezar a Maven o Gradle.
+- Si después de evaluar tu código llegas a la conclusión de que no puedes usar Maven o Gradle entonces debes de descargar todas las dependencias de la libreria e incluirlas en tu proyecto.
+
+- Crea un archivo `pom.xml` con el siguiente contenido:
+
+```xml
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>mygroup</groupId>
+    <artifactId>myartifact</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>My app</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.project-openubl</groupId>
+            <artifactId>xsender</artifactId>
+            <version>3.0.1.Final</version>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+- Abre un terminal y ubícate en la carpeta donde creaste el `pom.xml`
+- Ejecuta el comando:
+
+```shell
+mvn dependency:copy-dependencies
+```
+
+- Se creará una carpeta `target` al costado de `pom.xml`. Lo único que tienes que hacer es copiar todas las dependencias dentro de la carpeta `target/dependency` a tu proyecto.
+
+### Ejemplo
+
+`Carlos Alberto` Nos muestra un ejemplo de cómo usar las dependencias sin Maven o Gradle en [project-xbuilder-xsender-NO-MAVEN-GRADLE](https://github.com/xxsolracxx/project-xbuilder-xsender-NO-MAVEN-GRADLE)


### PR DESCRIPTION
El PR muestra como usar XBuilder sin Maven o Gradle. Gracias a la colaboración especial de CarlosAlberto